### PR TITLE
Optimize pathfinding

### DIFF
--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -23,6 +23,11 @@ typedef struct grid {
 typedef struct neighbourListNode {
     Node* curentNode;
     struct neighbourListNode* nextNode;
+} NeighbourListNode;
+
+typedef struct neighbourList {
+    NeighbourListNode* startNode;
+    NeighbourListNode* endNode;
 } NeighbourList;
 
 /* ----- Grid management functions ----- */
@@ -94,6 +99,20 @@ void processNeighbors(Grid* grid, Node* current, Node* target);
  * @return Pointer to the created neighbor list
  */
 NeighbourList* createNeighbourList();
+
+/**
+ * @brief Add a node to the neighbor list
+ * @param NeighbourList The list to add the node to
+ * @param node The node to add to the list
+ */
+void addNeighbour(NeighbourList* NeighbourList, Node* node);
+
+/**
+ * @brief Remove a node from the neighbor list
+ * @param NeighbourList The list to remove the node from
+ * @param node The node to remove from the list
+ */
+void removeNeighbour(NeighbourList* NeighbourList, Node* node);
 
 /**
  * @brief Free a neighbor list and all associated memory

--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -20,6 +20,11 @@ typedef struct grid {
     Node **cells;
 } Grid;
 
+typedef struct neighbourListNode {
+    Node* curentNode;
+    struct neighbourListNode* nextNode;
+} NeighbourList;
+
 /* ----- Grid management functions ----- */
 
 /**

--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -13,6 +13,7 @@ typedef struct node {
     float totalCost;
     int visited;
     int impassable;
+    int processed;
 } Node;
 
 typedef struct grid {

--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -83,7 +83,7 @@ float calculateEstimatedCost(int startX, int startY, int targetX, int targetY);
 /**
  * @brief Find the unvisited node with the lowest total cost
  * @param grid The grid to search in
- * @param processedNeighbourList List of neighbor nodes to be connsidered when geting the one with lowest cost
+ * @param processedNeighbourList List of neighbor nodes to be considered when getting the one with lowest cost
  * @return The lowest cost unvisited node, or NULL if none found
  */
 Node* getLowestCostNode(Grid* grid, NeighbourList* processedNeighbourList);

--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -82,17 +82,19 @@ float calculateEstimatedCost(int startX, int startY, int targetX, int targetY);
 /**
  * @brief Find the unvisited node with the lowest total cost
  * @param grid The grid to search in
+ * @param processedNeighbourList List of neighbor nodes to be connsidered when geting the one with lowest cost
  * @return The lowest cost unvisited node, or NULL if none found
  */
-Node* getLowestCostNode(Grid* grid);
+Node* getLowestCostNode(Grid* grid, NeighbourList* processedNeighbourList);
 
 /**
  * @brief Process neighbors of the current node during pathfinding
  * @param grid The grid being searched
  * @param current The current node being processed
  * @param target The target destination node
+ * @param processedNeighbourList List to track nodes that have been processed
  */
-void processNeighbors(Grid* grid, Node* current, Node* target);
+void processNeighbors(Grid* grid, Node* current, Node* target, NeighbourList* processedNeighbourList);
 
 /**
  * @brief Create a new empty linkedlist for storing neighboring nodes

--- a/include/pathfinding.h
+++ b/include/pathfinding.h
@@ -89,6 +89,18 @@ Node* getLowestCostNode(Grid* grid);
  */
 void processNeighbors(Grid* grid, Node* current, Node* target);
 
+/**
+ * @brief Create a new empty linkedlist for storing neighboring nodes
+ * @return Pointer to the created neighbor list
+ */
+NeighbourList* createNeighbourList();
+
+/**
+ * @brief Free a neighbor list and all associated memory
+ * @param neighbourList The neighbor list to free
+ */
+void freeNeighbourList(NeighbourList* neighbourList);
+
 /* ----- Path handling functions ----- */
 
 /**

--- a/src/pathfindning/pathfinding.c
+++ b/src/pathfindning/pathfinding.c
@@ -298,7 +298,7 @@ Node** findPath(Grid* grid, int startX, int startY, int targetX, int targetY) {
     Node* target = getNode(grid, targetX, targetY);
     Node* current = getNode(grid, startX, startY);
     
-    if (!target || !current || target->impassable || current->impassable) {
+    if (!target || !current || target->impassable || current->impassable || !isValid(grid,startX,startY) || !isValid(grid,targetX,targetY)) {
         return NULL;
     }
     

--- a/src/pathfindning/pathfinding.c
+++ b/src/pathfindning/pathfinding.c
@@ -173,8 +173,8 @@ NeighbourList* createNeighbourList() {
         return NULL;
     }
 
-    neighbourList->curentNode = NULL;
-    neighbourList->nextNode = NULL;
+    neighbourList->startNode = NULL;
+    neighbourList->endNode = NULL;
     
     return neighbourList;
 }
@@ -184,14 +184,16 @@ void freeNeighbourList(NeighbourList* neighbourList) {
         return;
     }
 
-    NeighbourList* current = neighbourList;
-    NeighbourList* next;
-    
+    NeighbourListNode* current = neighbourList->startNode;
+    NeighbourListNode* next;
+
     while (current != NULL) {
         next = current->nextNode;
         free(current);
         current = next;
     }
+    
+    free(neighbourList);
 }
 
 /**

--- a/src/pathfindning/pathfinding.c
+++ b/src/pathfindning/pathfinding.c
@@ -179,6 +179,58 @@ NeighbourList* createNeighbourList() {
     return neighbourList;
 }
 
+void addNeighbour(NeighbourList* neighbourList, Node* node) {
+    if (!neighbourList || !node) {
+        return;
+    }
+    
+    NeighbourListNode* newNode = (NeighbourListNode*)malloc(sizeof(NeighbourListNode));
+    if (!newNode) {
+        return;
+    }
+    
+    newNode->curentNode = node;
+    newNode->nextNode = NULL;
+    
+    if (!neighbourList->startNode) {
+        neighbourList->startNode = newNode;
+        neighbourList->endNode = newNode;
+    } else {
+        neighbourList->endNode->nextNode = newNode;
+        neighbourList->endNode = newNode;
+    }
+}
+
+void removeNeighbour(NeighbourList* neighbourList, Node* node) {
+    if (!neighbourList || !node || !neighbourList->startNode) {
+        return;
+    }
+    
+    NeighbourListNode* current = neighbourList->startNode;
+    NeighbourListNode* previous = NULL;
+    
+    while (current != NULL) {
+        if (current->curentNode != node) {
+            previous = current;
+            current = current->nextNode;
+            continue;
+        }
+        
+        if (previous == NULL) {
+            neighbourList->startNode = current->nextNode;
+        } else {
+            previous->nextNode = current->nextNode;
+        }
+        
+        if (neighbourList->endNode == current) {
+            neighbourList->endNode = previous;
+        }
+        
+        free(current);
+        return;
+    }
+}
+
 void freeNeighbourList(NeighbourList* neighbourList) {
     if (!neighbourList) {
         return;

--- a/src/pathfindning/pathfinding.c
+++ b/src/pathfindning/pathfinding.c
@@ -45,6 +45,7 @@ Grid* createGrid(int width, int height, float** heightInfo) {
             grid->cells[x][y].totalCost = FLT_MAX;
             grid->cells[x][y].visited = 0;
             grid->cells[x][y].impassable = 0;
+            grid->cells[x][y].processed = 0;
         }
     }
     
@@ -182,7 +183,7 @@ NeighbourList* createNeighbourList() {
 }
 
 void addNeighbour(NeighbourList* neighbourList, Node* node) {
-    if (!neighbourList || !node) {
+    if (!neighbourList || !node || node->processed) {
         return;
     }
     
@@ -201,6 +202,7 @@ void addNeighbour(NeighbourList* neighbourList, Node* node) {
         neighbourList->endNode->nextNode = newNode;
         neighbourList->endNode = newNode;
     }
+    node->processed = 1;
 }
 
 void removeNeighbour(NeighbourList* neighbourList, Node* node) {
@@ -312,13 +314,13 @@ Node** findPath(Grid* grid, int startX, int startY, int targetX, int targetY) {
     if (!processedNeighbourList) {
         return NULL;
     }
-    
+
     while (current != target) {
         current->visited = 1;
         
-        removeNeighbour(processedNeighbourList, current);
-        
         processNeighbors(grid, current, target, processedNeighbourList);
+        
+        removeNeighbour(processedNeighbourList, current);
         
         current = getLowestCostNode(grid, processedNeighbourList);
         
@@ -409,6 +411,7 @@ void resetGrid(Grid* grid) {
             grid->cells[x][y].estimatedCostToTarget = FLT_MAX;
             grid->cells[x][y].totalCost = FLT_MAX;
             grid->cells[x][y].visited = 0;
+            grid->cells[x][y].processed = 0;
         }
     }
 }

--- a/src/pathfindning/pathfinding.c
+++ b/src/pathfindning/pathfinding.c
@@ -166,6 +166,34 @@ void processNeighbors(Grid* grid, Node* current, Node* target) {
     }
 }
 
+NeighbourList* createNeighbourList() {
+    NeighbourList* neighbourList = (NeighbourList*)malloc(sizeof(NeighbourList));
+    
+    if (!neighbourList) {
+        return NULL;
+    }
+
+    neighbourList->curentNode = NULL;
+    neighbourList->nextNode = NULL;
+    
+    return neighbourList;
+}
+
+void freeNeighbourList(NeighbourList* neighbourList) {
+    if (!neighbourList) {
+        return;
+    }
+
+    NeighbourList* current = neighbourList;
+    NeighbourList* next;
+    
+    while (current != NULL) {
+        next = current->nextNode;
+        free(current);
+        current = next;
+    }
+}
+
 /**
  * Reconstructs the complete path from start to target by walking backwards through the linked nodes starting from the target node.
  * Returns a NULL-terminated array of Node pointers representing the path.


### PR DESCRIPTION
By only checking the neighbours when calling getLowestCostNode instead of traversingthe whole grid the algorithm is now more efficient.